### PR TITLE
CMake: Explicit dependency for Boost 1.54.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ addons:
                         - ubuntu-toolchain-r-test
                 packages:
                         - g++-7
-                        - libboost-all-dev
+                        - libboost-dev
 
 before_script:
         - sudo ln -s /usr/bin/g++-7 /usr/local/bin/g++

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@ A very basic, but customizable calculator.
 
 **(WIP)**
 
+## CI Status
+
+[![Build Status](https://travis-ci.org/rvarago/rvcalc.svg?branch=master)](https://travis-ci.org/rvarago/rvcalc)
+
 ## Usage
 
 **NOTE:** To compile you need a C++ compiler supporting C++ 14 (tested with g++ 7.3.0).

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,3 +1,7 @@
 add_library(core INTERFACE)
 target_include_directories(core INTERFACE include)
 target_compile_features(core INTERFACE cxx_std_14)
+
+find_package(Boost 1.54.0)
+
+target_link_libraries(core INTERFACE Boost::boost)

--- a/core/include/parser.hpp
+++ b/core/include/parser.hpp
@@ -11,7 +11,7 @@
 #include <utility>
 #include <vector>
 
-#include <boost/algorithm/string.hpp>
+#include "boost/algorithm/string.hpp"
 
 #include "symbols.hpp"
 


### PR DESCRIPTION
Explicit add boost as a depedency for the core.